### PR TITLE
Bug fixes and New Browser Version Check Header

### DIFF
--- a/hooks/useBrowserValid.jsx
+++ b/hooks/useBrowserValid.jsx
@@ -1,0 +1,36 @@
+import React, { useState } from "react";
+import { useEffect } from "react";
+import { detect } from "detect-browser";
+
+const formatVersion = (version = "0.0") => {
+    return Number(version.split(".")[0]) || 0;
+};
+
+const useBrowserValid = () => {
+    const browser = detect();
+    const [isBrowserValid, setIsBrowserValid] = useState(true);
+    useEffect(() => {
+        console.log("checking browser" + browser.name);
+        switch (true) {
+            case browser.name === "chrome" && formatVersion(browser.version) < 96:
+                setIsBrowserValid(false);
+                break;
+            case browser.name === "firefox" && formatVersion(browser.version) < 79:
+                setIsBrowserValid(false);
+                break;
+            case (browser.name === "edge" || browser.name === "edge-chromium" || browser.name === "edge-ios") && formatVersion(browser.version) < 98:
+                setIsBrowserValid(false);
+                break;
+            case (browser.name === "opera" || browser.name === "opera-mini") && formatVersion(browser.version) < 83:
+                setIsBrowserValid(false);
+                break;
+
+            default:
+                break;
+        }
+    }, [browser]);
+
+    return {isBrowserValid, browserVersion: browser.version};
+};
+
+export default useBrowserValid;

--- a/sidebar/sidebar.js
+++ b/sidebar/sidebar.js
@@ -176,9 +176,11 @@ const Sidebar = ({ variant, isDark, isDesktop }) => {
 			zIndex={1}
 			position={"relative"}
 		>
-			<Center w="full" h="54px" mb="5">
-				<Image src="/ed_logo.png" alt="" width="21px" height="21px" />
-			</Center>
+			<Link href={MAIN_URL}>
+				<Center w="full" h="54px" mb="5">
+					<Image src="/ed_logo.png" alt="" width="21px" height="21px" />
+				</Center>
+			</Link>
 			<Divider borderColor={borderColor} />
 			<SidebarContent isDark={isDark} isDesktop={isDesktop} sidebar_variant={variant} />
 		</Box>

--- a/subComponents/browserCheck/index.jsx
+++ b/subComponents/browserCheck/index.jsx
@@ -1,39 +1,15 @@
 import React from "react";
 import { CloseButton, Flex, Slide, Text, useColorModeValue, useDisclosure } from "@chakra-ui/react";
-import { useState } from "react";
-import { detect } from "detect-browser";
+import useBrowserValid from "../../hooks/useBrowserValid";
 
 const BrowserVersionCheckHeader = () => {
-    const browser = detect();
-    const [isBrowserValid, setIsBrowserValid] = useState(true);
+    const {isBrowserValid, browserVersion} = useBrowserValid();
     const bg = useColorModeValue("backgrounds.light.e100", "backgrounds.dark.e100");
     const hover = useColorModeValue("backgrounds.light.e200", "backgrounds.dark.e200");
 
     const { isOpen, onClose } = useDisclosure({ defaultIsOpen: true });
 
-    const formatVersion = (version = "0.0") => {
-        return Number(version.split(".")[0]) || 0;
-    };
-
-    switch (browser && browser.version) {
-        case "chrome":
-            if (formatVersion(browser.version) < 96) setIsBrowserValid(false);
-            break;
-        case "firefox":
-            if (formatVersion(browser.version) < 79) setIsBrowserValid(false);
-            break;
-        case "edge":
-            if (formatVersion(browser.version) < 98) setIsBrowserValid(false);
-            break;
-        case "opera":
-            if (formatVersion(browser.version) < 83) setIsBrowserValid(false);
-            break;
-
-        default:
-            break;
-    }
-
-    return isBrowserValid ? (
+    return !isBrowserValid ? (
         <Slide direction="top" in={isOpen} style={{ zIndex: "9999" }}>
             <Flex
                 //position={"fixed"}
@@ -51,7 +27,7 @@ const BrowserVersionCheckHeader = () => {
                 borderBottomRadius={"6px"}
             >
                 <Text>
-                    Your browser version <Text as="b">{browser.version}</Text> does not meet the
+                    Your browser version <Text as="b">{browserVersion}</Text> does not meet the
                     supported minimum requirements! Please consider updating it to the latest
                     version.
                 </Text>

--- a/subComponents/browserCheck/index.jsx
+++ b/subComponents/browserCheck/index.jsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { CloseButton, Flex, Slide, Text, useColorModeValue, useDisclosure } from "@chakra-ui/react";
+import { useState } from "react";
+import { detect } from "detect-browser";
+
+const BrowserVersionCheckHeader = () => {
+    const browser = detect();
+    const [isBrowserValid, setIsBrowserValid] = useState(true);
+    const bg = useColorModeValue("backgrounds.light.e100", "backgrounds.dark.e100");
+    const hover = useColorModeValue("backgrounds.light.e200", "backgrounds.dark.e200");
+
+    const { isOpen, onClose } = useDisclosure({ defaultIsOpen: true });
+
+    const formatVersion = (version = "0.0") => {
+        return Number(version.split(".")[0]) || 0;
+    };
+
+    switch (browser && browser.version) {
+        case "chrome":
+            if (formatVersion(browser.version) < 96) setIsBrowserValid(false);
+            break;
+        case "firefox":
+            if (formatVersion(browser.version) < 79) setIsBrowserValid(false);
+            break;
+        case "edge":
+            if (formatVersion(browser.version) < 98) setIsBrowserValid(false);
+            break;
+        case "opera":
+            if (formatVersion(browser.version) < 83) setIsBrowserValid(false);
+            break;
+
+        default:
+            break;
+    }
+
+    return isBrowserValid ? (
+        <Slide direction="top" in={isOpen} style={{ zIndex: "9999" }}>
+            <Flex
+                //position={"fixed"}
+                w={"100vw"}
+                zIndex={"9999"}
+                h={"fit-content"}
+                p={"4"}
+                bg={bg}
+                _hover={{ bg: hover }}
+                transition={"all 300ms ease"}
+                boxShadow={"0 0.4rem 0.25rem rgba(0, 0, 0, 0.2);"}
+                justifyContent={"center"}
+                alignItems={"center"}
+                gap={2}
+                borderBottomRadius={"6px"}
+            >
+                <Text>
+                    Your browser version <Text as="b">{browser.version}</Text> does not meet the
+                    supported minimum requirements! Please consider updating it to the latest
+                    version.
+                </Text>
+                <CloseButton onClick={onClose} />
+            </Flex>
+        </Slide>
+    ) : null;
+};
+
+export default BrowserVersionCheckHeader;


### PR DESCRIPTION
### Browser Check Header
Uses the [detect-browser](https://www.npmjs.com/package/detect-browser) package and switch case hook a877f869b72519c1f852f19ad0615569bc1ded9b to conditionally render a banner in the app layout component with `zIndex: 9999`
Currently this has been added to the following repos:

1. components
2. home
3. timeline
4. classrooms

Note: If the components submodule is not updated to the latest commit using `git submodule update --recursive` then there will be a file not found error, due to the lack of the browser check component 